### PR TITLE
【STEP1】ChainlitでOpenAIのAPIを使えるようにしてチャットボットを作る

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,1 +1,9 @@
-chainlit==1.0.200
+chainlit==1.0.401
+langchain==0.1.13
+langchain-community==0.0.29
+langchain-openai==0.1.1
+langchain-core==0.1.36
+langchain-text-splitters==0.0.1
+langsmith==0.1.38
+openai==1.13.3
+python-dotenv==1.0.1

--- a/src/config.py
+++ b/src/config.py
@@ -1,0 +1,10 @@
+import os
+
+from dotenv import load_dotenv
+
+# .envファイルへの相対パス
+env_path = os.path.join(os.path.dirname(__file__), '..', '.env')
+load_dotenv(dotenv_path=env_path)
+
+# 環境変数を取得
+OPENAI_API_KEY = os.getenv('OPENAI_API_KEY')

--- a/src/demo.py
+++ b/src/demo.py
@@ -1,24 +1,38 @@
+#https://qiita.com/skkzsh/items/17bff703dba27240ec90のほぼコピー
+
+#環境変数の読み込み
+import config
+
+openai_client_key = config.OPENAI_API_KEY
+
+#必要なライブラリの読み込み
 import chainlit as cl
+from langchain.prompts import ChatPromptTemplate
+from langchain.schema import StrOutputParser
+from langchain.schema.runnable import Runnable
+from langchain.schema.runnable.config import RunnableConfig
+from langchain_openai import ChatOpenAI
 
 
-@cl.step
-def tool():
-    return "Response from the tool!"
+#chainlitとlangchainを利用してチャットボットのUIと機能を作る。
+@cl.on_chat_start
+async def on_chat_start():
+    model = ChatOpenAI(streaming=True)
+    prompt = ChatPromptTemplate.from_messages([("human", "{question}"),
+        ])
+    runnable = prompt | model | StrOutputParser()
+    cl.user_session.set("runnable", runnable)
 
+@cl.on_message
+async def on_message(message: cl.Message):
+    runnable = cl.user_session.get("runnable")  # type: Runnable
 
-@cl.on_message  # this function will be called every time a user inputs a message in the UI
-async def main(message: cl.Message):
-    """
-    This function is called every time a user inputs a message in the UI.
-    It sends back an intermediate response from the tool, followed by the final answer.
-    Args:
-        message: The user's message.
-    Returns:
-        None.
-    """
+    msg = cl.Message(content="")
 
-    # Call the tool
-    tool()
+    async for chunk in runnable.astream(
+        {"question": message.content},
+        config=RunnableConfig(callbacks=[cl.LangchainCallbackHandler()]),
+    ):
+        await msg.stream_token(chunk)
 
-    # Send the final answer.
-    await cl.Message(content="This is the final answer").send()
+    await msg.send()


### PR DESCRIPTION
### 【STEP1】ChainlitでOpenAIのAPIを使えるようにしてチャットボットを作成
概要
このプルリクエストでは、Issue #1 の要件に従い、Chainlitを使用してOpenAIのAPIを統合し、インタラクティブなLLMエージェントと会話ができるチャットボットを実装しました。

主な変更点
**OpenAI APIキーの取得と設定:**.env ファイルを作成し、APIキーを安全に管理しました。
**Chainlitアプリの実装:** Chainlitのフレームワークを使用して、ユーザー入力を受け取り、OpenAIのAPIを呼び出してレスポンスを表示するシンプルなUIを作成しました。


参考資料
・[公式のgetting start]　(https://docs.chainlit.io/integrations/langchain)
・[Qiita記事]　(https://qiita.com/skkzsh/items/17bff703dba27240ec90)

開発のヒント

詳細な開発手順やヒントについては、開発例のヒントを参照してください。(https://github.com/matsuoinstitute/chatbot-demo/wiki/%E9%96%8B%E7%99%BA%E4%BE%8B%E3%81%AE%E3%83%92%E3%83%B3%E3%83%88)